### PR TITLE
fix(dist): add produciton env to babelrc and prepublish step

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,9 @@
     },
     "test": {
       "presets": ["es2015", "react",]
+    },
+    "production": {
+      "presets": ["es2015", "react",]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "NODE_ENV=development node server.js",
     "test": "NODE_ENV=test mocha --require babel-core/register --recursive && standard",
     "test:watch": "npm run test -- --watch",
-    "prepublish": "mkdir -p dist && babel src --out-dir dist",
+    "prepublish": "NODE_ENV=production mkdir -p dist && babel src --out-dir dist",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "main": "dist/manhattan.js",


### PR DESCRIPTION
react-hmre was causing an error after installing. moving publish to the production env and excluding
hmre from the presets fixes this.

closes #13
