### PR TITLE
fix(makeElement): pass all props to underlying element and clean the …

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -30,7 +30,7 @@ class App extends Component {
             </Flex>
           </M1>
         </Block>
-        <TextLeft>Left</TextLeft>
+        <TextLeft onClick={() => console.log('click click click')}>Left</TextLeft>
         <TextCenter>Centered</TextCenter>
         <TextRight>Right</TextRight>
         <TextJustify>Lorem ipsum dolor sit amet</TextJustify>

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,8 +3,18 @@ import React, { Component } from 'react'
 const makeElement = (style) => class extends Component {
   render () {
     const { children } = this.props
-    return <div style={Object.assign({}, style, this.props)}>{children}</div>
+    return <div {...this.props} style={assignStyle(style, this.props)}>{children}</div>
   }
+}
+
+export const assignStyle = (style, propsObject) => {
+  const excludeKeys = ['children', 'onClick', 'onMouseEnter', 'onMouseLeave']
+  let elementStyles = Object.assign({}, style, propsObject)
+
+  for (var key in excludeKeys) {
+    delete elementStyles[excludeKeys[key]]
+  }
+  return elementStyles
 }
 
 export const toTitleCase = (str) =>

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import expect from 'expect'
 import { shallow } from 'enzyme'
-import makeElement, { generateProperties, toTitleCase } from '../src/utils'
+import makeElement, { assignStyle, generateProperties, toTitleCase } from '../src/utils'
 
 describe('utils', () => {
   describe('makeElement', () => {
@@ -45,6 +45,26 @@ describe('utils', () => {
     it('should convert a string to title case', () =>
         expect(toTitleCase('down')).toEqual('Down')
     )
+  })
+
+  describe('assignStyle', () => {
+    it('should remove invalid keys from the style object', () => {
+      const propsObject = {
+        onClick: {},
+        onMouseEnter: {},
+        onMouseLeave: {},
+        children: {},
+        paddingLeft: '1em'
+      }
+      const style = {
+        display: 'block'
+      }
+      const expected = {
+        paddingLeft: '1em',
+        display: 'block'
+      }
+      expect(assignStyle(style, propsObject)).toEqual(expected)
+    })
   })
 
   describe('generateProperties', () => {


### PR DESCRIPTION
…style object

makeElement now passes all props to the div it renders allowing for onClick and other dom events.
the style object is also cleaned of the most common non style props likely to be passed for a
lighter dom and more useful style inspector.

closes #24 #5
